### PR TITLE
[FEAT] Add PixelArch container setup

### DIFF
--- a/.codex/tasks/done/9e342104-add-docker-compose-pixelarch.md
+++ b/.codex/tasks/done/9e342104-add-docker-compose-pixelarch.md
@@ -1,0 +1,15 @@
+# Add Docker Compose configuration for PixelArch
+
+## Problem
+There is no Docker Compose file to orchestrate the PixelArch container.
+
+## Tasks
+- [x] Create `docker-compose.yml` at the repository root that builds the image from the local `Dockerfile`.
+- [x] Define a service named `lyra` with `container_name: lyra`, `command: uv run lyra.py`, and mount the repository into `/app`.
+- [x] Ensure the compose file uses standard Docker Compose directives.
+- [x] Add comments describing how to start and stop the service, e.g., `docker compose up -d --build` and `docker compose down`.
+
+## Acceptance Criteria
+- Running `docker compose up -d --build` builds and starts the service without errors.
+- Service uses the local `Dockerfile` and runs `uv run lyra.py`.
+- Comments clearly explain start and stop commands.

--- a/.codex/tasks/done/e5d267cf-add-pixelarch-dockerfile.md
+++ b/.codex/tasks/done/e5d267cf-add-pixelarch-dockerfile.md
@@ -1,0 +1,15 @@
+# Add PixelArch Dockerfile for containerized setup
+
+## Problem
+The repository lacks a Dockerfile to run Lyra using the PixelArch base image.
+
+## Tasks
+- [x] Create `Dockerfile` at the repository root starting from `lunamidori5/pixelarch:quartz`.
+- [x] Rename the distribution to `Lyra-Runner` and install `wget`, `unzip`, and `uv` with `yay`, cleaning the package cache after each step.
+- [x] Set `/app` as the working directory, adjust ownership and permissions, and make the image run `uv run lyra.py` by default.
+- [x] Add comments showing how to build and run the image using Docker commands, e.g., `docker build -t lyra .` and `docker run --rm lyra`.
+
+## Acceptance Criteria
+- `Dockerfile` builds successfully.
+- Image created from the `Dockerfile` runs the project without errors.
+- Comments clearly document build and runtime commands.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# PixelArch-based runtime for Lyra
+#
+# Build with:
+#   docker build -t lyra .
+# Run with:
+#   docker run --rm -it -v $(pwd):/app lyra
+
+FROM lunamidori5/pixelarch:quartz
+
+# Rename distribution for clarity
+RUN sudo sed -i 's/Quartz/Lyra-Runner/g' /etc/os-release
+
+# Install utilities and clean cache
+RUN yay -Syu --noconfirm wget && yay -Yccc --noconfirm
+RUN yay -Syu --noconfirm unzip && yay -Yccc --noconfirm
+RUN yay -Syu --noconfirm uv && yay -Yccc --noconfirm
+
+# Show build-time user info
+RUN echo "User: $(whoami), UID: $(id -u), GID: $(id -g)"
+
+WORKDIR /app
+
+# Ensure proper ownership and permissions
+RUN sudo chown -R $(whoami):$(whoami) /app && sudo chmod -R 755 /app
+
+CMD ["uv", "run", "lyra.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# Compose setup for Lyra with PixelArch
+# Start with: docker compose up -d --build
+# Stop with:  docker compose down
+
+services:
+  lyra:
+    build: .
+    container_name: lyra
+    command: uv run lyra.py
+    volumes:
+      - .:/app
+    working_dir: /app


### PR DESCRIPTION
## Summary
- add PixelArch Dockerfile based on `lunamidori5/pixelarch:quartz` with docker build/run instructions
- add docker-compose configuration for PixelArch service using `docker compose up -d --build`
- update task descriptions to reference standard Docker commands
- mark PixelArch tasks as complete in `.codex/tasks/done/`

## Testing
- `uv run pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_68914a4f4238832ca0b59f61b17fb7f5