### PR TITLE
[STYLE] Split typing imports in encrypted storage

### DIFF
--- a/src/journal/encrypted_torch_storage.py
+++ b/src/journal/encrypted_torch_storage.py
@@ -7,8 +7,10 @@ while maintaining full Pydantic validation and type safety.
 import io
 import os
 import json
+
+from typing import Any
+from typing import TypeVar
 from pathlib import Path
-from typing import Any, TypeVar
 
 import torch
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary
- split `Any` and `TypeVar` into separate typing imports in encrypted torch storage

## Testing
- `uv run pytest -v`
- `uv run lyra.py --help`
- `uv run python -c "import src.cli.chat; print('Imports working')"`


------
https://chatgpt.com/codex/tasks/task_b_68ba8cc8a1fc832ca8a1ad1621862bbd