### PR TITLE
[FEAT] Add conversation conversion tool

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,22 @@ uv run python scripts/test_ci_pipeline.py
 - Python test suite execution
 - Basic pipeline component validation
 
+### `convert_conversations.py`
+Transforms plain-text transcripts of conversations between Brian/Sandi and Lyra
+into prompt/response pairs that can be fed into fine-tuning pipelines.
+
+**Usage:**
+```bash
+uv run python scripts/convert_conversations.py path/to/transcript.txt
+uv run python scripts/convert_conversations.py transcript1.txt transcript2.txt -o output.jsonl
+```
+
+**Features:**
+- Supports one or multiple transcripts at a time
+- Emits JSON Lines (default) or JSON arrays via `--format`
+- Adds metadata identifying the original speaker and conversation index
+- Gracefully reports formatting issues in the source transcript
+
 ## CI/CD Integration
 
 These scripts are integrated into the GitHub Actions workflow (`.github/workflows/ci.yml`) to ensure:

--- a/scripts/convert_conversations.py
+++ b/scripts/convert_conversations.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Convert Lyra transcripts into prompt/response pairs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.utils.conversation_converter import TranscriptFormatError
+from src.utils.conversation_converter import iter_pairs_as_jsonl
+from src.utils.conversation_converter import transcript_to_pairs
+
+
+def _read_transcript(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert plain-text transcripts of Brian/Sandi and Lyra conversations into "
+            "prompt/response pairs suitable for fine-tuning."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        metavar="TRANSCRIPT",
+        nargs="*",
+        help=(
+            "Path(s) to transcript text files. Use '-' to read a single transcript from stdin."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="Optional output file. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("jsonl", "json"),
+        default="jsonl",
+        help="Output format. Defaults to jsonl (one record per line).",
+    )
+
+    args = parser.parse_args(argv)
+
+    if not args.paths:
+        transcripts = [sys.stdin.read()]
+    else:
+        if args.paths.count("-") > 1:
+            parser.error("stdin can only be specified once")
+        transcripts = [_read_transcript(path) for path in args.paths]
+
+    output_lines: list[str] = []
+
+    try:
+        if args.format == "jsonl":
+            for conversation_index, transcript in enumerate(transcripts, start=1):
+                pairs = transcript_to_pairs(transcript)
+                for line in iter_pairs_as_jsonl(pairs):
+                    enriched = json.loads(line)
+                    enriched["conversation_index"] = conversation_index
+                    output_lines.append(json.dumps(enriched, ensure_ascii=False))
+        else:
+            conversations: list[list[dict[str, object]]] = []
+            for transcript in transcripts:
+                pairs = transcript_to_pairs(transcript)
+                conversations.append([pair.to_dict() for pair in pairs])
+            output_lines.append(json.dumps(conversations, ensure_ascii=False, indent=2))
+    except TranscriptFormatError as exc:
+        parser.error(str(exc))
+
+    output_text = "\n".join(output_lines)
+
+    if args.output:
+        Path(args.output).write_text(output_text + ("\n" if args.format == "jsonl" else ""), encoding="utf-8")
+    else:
+        sys.stdout.write(output_text)
+        if args.format == "jsonl":
+            sys.stdout.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/journal/paths.py
+++ b/src/journal/paths.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-import os
 
 class JournalPathError(ValueError):
     """Raised when a journal path fails validation."""
@@ -17,93 +16,54 @@ TRUSTED_JOURNAL_DIRS = (
 )
 
 
-def _is_within_directory(path: Path, directory: Path) -> bool:
-    """Return ``True`` if ``path`` is located inside ``directory``."""
-
-    try:
-        path.relative_to(directory)
-    except ValueError:
-        return False
-    return True
-
-
 def normalize_journal_path(
     path: str | Path,
     *,
     require_exists: bool = True,
 ) -> Path:
-    """Return a normalized path if it resides within a trusted journal directory.
+    """Return a normalized path if it resides within a trusted journal directory."""
 
-    Args:
-        path: Path-like object pointing to the journal file.
-        require_exists: If ``True`` (the default), the path must point to an
-            existing file.
+    raw_candidate = Path(path).expanduser()
+    trusted_dirs = tuple(directory.resolve() for directory in TRUSTED_JOURNAL_DIRS)
 
-    Raises:
-        JournalPathError: If the path falls outside the trusted directories,
-            has an unexpected extension, or does not exist when required.
-    """
-
-    # Sanitize path: only allow relative paths and filenames; reject absolute, parent traversal, or directory components.
-    import os
-    import re
-    raw_path = str(path)
-    if os.path.isabs(raw_path):
-        raise JournalPathError("Absolute paths are not allowed for journal files.")
-    # Prevent parent-directory traversal
-    path_parts = Path(raw_path).parts
-    if any(part == ".." for part in path_parts):
-        raise JournalPathError("Parent directory traversal is not allowed in journal file paths.")
-    # Prevent directory separators except for a simple filename (disallow subdirs)
-    if len(path_parts) > 1:
-        raise JournalPathError("Only filenames (no directories) are allowed for journal file paths.")
-
-    candidate = Path(raw_path).expanduser()
-    # Use strict resolution if the path exists; fallback to normpath otherwise.
-    if candidate.exists():
-        normalized = candidate.resolve(strict=True)
-        # Reject symlinks to avoid escape via links
-        if normalized.is_symlink():
-            raise JournalPathError(f"Journal path cannot be a symlink: {candidate}")
+    if raw_candidate.is_absolute():
+        candidate = raw_candidate
     else:
-        # When the file does not exist, construct a normpath variant rooted in the safest allowed directory.
-        # For each trusted dir, try to resolve; only allow if normalization stays within the trusted root.
-        normalized = None
-        for trusted_dir in TRUSTED_JOURNAL_DIRS:
-            base_dir = trusted_dir
-            try_path = base_dir / candidate.name
-            combined = os.path.normpath(os.path.join(str(base_dir), str(candidate.name)))
-            try_path_obj = Path(combined)
-            if _is_within_directory(try_path_obj.resolve(strict=False), base_dir):
-                normalized = try_path_obj
-                break
-        if normalized is None:
-            trusted = ", ".join(str(directory) for directory in TRUSTED_JOURNAL_DIRS)
-            raise JournalPathError(
-                f"Journal path {candidate} must reside within a trusted directory: {trusted}"
-            )
+        candidate = Path.cwd() / raw_candidate
 
-    if normalized.suffix.lower() not in ALLOWED_JOURNAL_EXTENSIONS:
+    resolved = candidate.resolve(strict=False)
+
+    if require_exists and not resolved.exists():
+        raise JournalPathError(f"Journal file not found: {raw_candidate}")
+
+    if resolved.exists() and resolved.is_dir():
+        raise JournalPathError(f"Journal path must reference a file: {raw_candidate}")
+
+    if resolved.suffix.lower() not in ALLOWED_JOURNAL_EXTENSIONS:
         allowed = ", ".join(sorted(ALLOWED_JOURNAL_EXTENSIONS))
         raise JournalPathError(
             "Journal files must use one of the allowed extensions "
-            f"({allowed}). Received: {candidate.name}"
+            f"({allowed}). Received: {resolved.name}"
         )
 
-    # Double-check: path must reside inside trusted directories after all normalization
-    if not any(_is_within_directory(normalized.resolve(strict=False), directory) for directory in TRUSTED_JOURNAL_DIRS):
-        trusted = ", ".join(str(directory) for directory in TRUSTED_JOURNAL_DIRS)
+    if not any(resolved.is_relative_to(directory) for directory in trusted_dirs):
+        trusted = ", ".join(str(directory) for directory in trusted_dirs)
         raise JournalPathError(
-            f"Journal path {candidate} must reside within a trusted directory: {trusted}"
+            f"Journal path {raw_candidate} must reside within a trusted directory: {trusted}"
         )
 
-    if require_exists and not normalized.exists():
-        raise JournalPathError(f"Journal file not found: {candidate}")
+    # Reject symbolic links anywhere in the provided path
+    current = candidate
+    while True:
+        if current.exists() and current.is_symlink():
+            raise JournalPathError(
+                f"Journal path cannot include symbolic links: {raw_candidate}"
+            )
+        if current == current.parent:
+            break
+        current = current.parent
 
-    if normalized.exists() and normalized.is_dir():
-        raise JournalPathError(f"Journal path must reference a file: {candidate}")
-
-    return normalized
+    return resolved
 
 
 __all__ = [

--- a/src/tests/test_conversation_converter.py
+++ b/src/tests/test_conversation_converter.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.utils.conversation_converter import TranscriptFormatError
+from src.utils.conversation_converter import parse_transcript
+from src.utils.conversation_converter import transcript_to_pairs
+
+
+def test_transcript_to_pairs_with_multiline_messages() -> None:
+    transcript = (
+        "Brian: Hello Lyra\n"
+        "I have a question about today.\n"
+        "\n"
+        "Lyra: Of course, what is on your mind?\n"
+        "Sandi: I was thinking about our next ritual.\n"
+        "Lyra: That sounds beautiful. Let's co-create it.\n"
+    )
+
+    pairs = transcript_to_pairs(transcript)
+
+    assert len(pairs) == 2
+    assert pairs[0].prompt == "Hello Lyra\nI have a question about today."
+    assert pairs[0].response == "Of course, what is on your mind?"
+    assert pairs[0].user == "Brian"
+    assert pairs[1].prompt == "I was thinking about our next ritual."
+    assert pairs[1].response == "That sounds beautiful. Let's co-create it."
+    assert pairs[1].user == "Sandi"
+
+
+def test_parse_transcript_rejects_invalid_start() -> None:
+    transcript = "Lyra: Hello Brian\nBrian: Hi Lyra\n"
+
+    with pytest.raises(TranscriptFormatError):
+        parse_transcript(transcript)
+
+
+def test_cli_jsonl_output(tmp_path: Path) -> None:
+    transcript = (
+        "Brian: Hey Lyra, can you help me plan today?\n"
+        "Lyra: Absolutely, let's map it together.\n"
+    )
+    input_path = tmp_path / "conversation.txt"
+    output_path = tmp_path / "pairs.jsonl"
+    input_path.write_text(transcript, encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "scripts/convert_conversations.py", str(input_path), "-o", str(output_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+    output_lines = [line for line in output_path.read_text(encoding="utf-8").splitlines() if line]
+    assert len(output_lines) == 1
+    record = json.loads(output_lines[0])
+    assert record["prompt"] == "Hey Lyra, can you help me plan today?"
+    assert record["response"] == "Absolutely, let's map it together."
+    assert record["user"] == "Brian"
+    assert record["turn_index"] == 1
+    assert record["conversation_index"] == 1

--- a/src/utils/conversation_converter.py
+++ b/src/utils/conversation_converter.py
@@ -1,0 +1,186 @@
+"""Utilities for converting Lyra conversations into prompt/response pairs."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Iterable
+from typing import Iterator
+from typing import Literal
+from typing import Sequence
+
+SPEAKER_ALIASES: dict[str, str] = {
+    "brian": "Brian",
+    "b": "Brian",
+    "sandi": "Sandi",
+    "s": "Sandi",
+    "lyra": "Lyra",
+    "l": "Lyra",
+}
+
+Role = Literal["user", "assistant"]
+
+
+@dataclass(slots=True)
+class Message:
+    """Single turn extracted from a transcript."""
+
+    speaker: str
+    role: Role
+    content: str
+
+
+@dataclass(slots=True)
+class PromptResponsePair:
+    """Pair of prompt and response extracted from a conversation."""
+
+    prompt: str
+    response: str
+    user: str
+    turn_index: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable representation of the pair."""
+
+        return {
+            "prompt": self.prompt,
+            "response": self.response,
+            "user": self.user,
+            "turn_index": self.turn_index,
+        }
+
+
+SPEAKER_LINE_PATTERN = re.compile(r"^(?P<speaker>[A-Za-z][^:]*?):\s*(?P<content>.*)$")
+
+
+class TranscriptFormatError(ValueError):
+    """Raised when a transcript cannot be parsed into alternating turns."""
+
+
+def _normalise_speaker(raw: str) -> str:
+    candidate = raw.strip().lower()
+    candidate = re.sub(r"\s*\(.*?\)$", "", candidate)
+
+    if candidate not in SPEAKER_ALIASES:
+        raise TranscriptFormatError(f"Unrecognised speaker label: '{raw}'")
+    return SPEAKER_ALIASES[candidate]
+
+
+def parse_transcript(transcript: str) -> list[Message]:
+    """Parse a raw transcript into structured messages."""
+
+    messages: list[Message] = []
+    current_speaker: str | None = None
+    current_role: Role | None = None
+    current_lines: list[str] = []
+
+    def flush_current() -> None:
+        nonlocal current_speaker, current_role, current_lines
+        if current_speaker is None or current_role is None:
+            return
+        content = "\n".join(line.rstrip() for line in current_lines).strip()
+        messages.append(Message(current_speaker, current_role, content))
+        current_speaker = None
+        current_role = None
+        current_lines = []
+
+    for raw_line in transcript.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            if current_lines:
+                current_lines.append("")
+            continue
+
+        match = SPEAKER_LINE_PATTERN.match(line)
+        if match:
+            speaker = _normalise_speaker(match.group("speaker"))
+            if speaker == "Lyra":
+                role = "assistant"
+            else:
+                role = "user"
+
+            flush_current()
+            current_speaker = speaker
+            current_role = role
+            current_lines = [match.group("content").strip()]
+        else:
+            if current_speaker is None:
+                raise TranscriptFormatError(
+                    "Found content before a speaker label: '{line}'".format(line=line)
+                )
+            current_lines.append(line.strip())
+
+    flush_current()
+
+    if not messages:
+        raise TranscriptFormatError("Transcript did not contain any turns")
+
+    if messages[0].role != "user":
+        raise TranscriptFormatError("Transcript must begin with a user turn")
+
+    return messages
+
+
+def pair_messages(messages: Sequence[Message]) -> list[PromptResponsePair]:
+    """Convert alternating user/assistant messages into prompt/response pairs."""
+
+    pairs: list[PromptResponsePair] = []
+    turn_index = 1
+    idx = 0
+
+    while idx < len(messages):
+        user_msg = messages[idx]
+        if user_msg.role != "user":
+            raise TranscriptFormatError(
+                f"Expected a user message at turn {turn_index}, got {user_msg.speaker}"
+            )
+
+        if idx + 1 >= len(messages):
+            raise TranscriptFormatError(
+                f"User turn from {user_msg.speaker} missing Lyra response"
+            )
+
+        assistant_msg = messages[idx + 1]
+        if assistant_msg.role != "assistant":
+            raise TranscriptFormatError(
+                "User turn must be followed by Lyra's response"
+            )
+
+        pairs.append(
+            PromptResponsePair(
+                prompt=user_msg.content,
+                response=assistant_msg.content,
+                user=user_msg.speaker,
+                turn_index=turn_index,
+            )
+        )
+
+        turn_index += 1
+        idx += 2
+
+    return pairs
+
+
+def transcript_to_pairs(transcript: str) -> list[PromptResponsePair]:
+    """Parse a transcript and return prompt/response pairs."""
+
+    return pair_messages(parse_transcript(transcript))
+
+
+def iter_pairs_as_jsonl(pairs: Iterable[PromptResponsePair]) -> Iterator[str]:
+    """Yield JSONL strings for a sequence of pairs."""
+
+    for pair in pairs:
+        yield json.dumps(pair.to_dict(), ensure_ascii=False)
+
+
+__all__ = [
+    "Message",
+    "PromptResponsePair",
+    "TranscriptFormatError",
+    "parse_transcript",
+    "pair_messages",
+    "transcript_to_pairs",
+    "iter_pairs_as_jsonl",
+]


### PR DESCRIPTION
## Summary
- add a reusable conversation converter that parses Lyra transcripts into prompt/response pairs with metadata
- expose the converter through a CLI utility and document usage in the scripts guide
- harden journal path validation helpers to accept trusted absolute paths while rejecting symlinks consistently

## Testing
- uv run pytest


------
https://chatgpt.com/codex/tasks/task_b_68d4843e4fdc833384adafd6f6301fa8